### PR TITLE
read data from NASA earthaccess and parse with insitupy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# temporary scratch files
+
+downloaded_file.csv
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/notebooks/data/fake_data.csv
+++ b/notebooks/data/fake_data.csv
@@ -1,0 +1,10 @@
+# PitID, some pit id
+# Location,East River
+# Date/Local Standard Time,2020-04-27T08:45
+# Latitude,38.92524
+# Longitude,-106.97112
+# Flags,random flag
+# Top (cm),Bottom (cm),Density (kg/m3)
+95.0,85.0,401.0
+85.0,75.0,449.0
+75.0,65.0,472.0

--- a/notebooks/scratch_space.ipynb
+++ b/notebooks/scratch_space.ipynb
@@ -27,10 +27,349 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cfa50fcd",
+   "id": "9b4d18a3",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "from snowexdb.utils.data_parser import download_csv, parse_csv_data\n",
+    "from snowexdb.utils.access_data import NSIDC_access\n",
+    "\n",
+    "collections = NSIDC_access(\"10.5067/KZ43HVLZV6G4\")\n",
+    "\n",
+    "\n",
+    "for collection in collections:\n",
+    "    files = collection.data_links(\"Data\")\n",
+    "    for file in files:\n",
+    "        if \"density\" in file:\n",
+    "            data = download_csv(file)\n",
+    "            profileData = parse_csv_data(\"data/downloaded_file.csv\")\n",
+    "            for index, profile in enumerate(profileData.profiles):\n",
+    "                profile.df.to_csv(\"data/observations{}.csv\".format(index))\n",
+    "                print(profile.metadata)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "id": "3d03be8a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Could not find mapping for pit_comments\n",
+      "Could not find mapping for parameter_codes\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CSV file downloaded successfully as 'downloaded_file.csv'\n",
+      "ProfileMetaData(site_name='COFEJ2_20191216_1232', date_time=Timestamp('2019-12-16 19:32:00+0000', tz='UTC'), latitude=39.90614, longitude=-105.88261, utm_epsg='26913', campaign_name='Fraser Experimental Forest', flags=None, comments=None, observers=None)\n",
+      "ProfileMetaData(site_name='COFEJ2_20191216_1232', date_time=Timestamp('2019-12-16 19:32:00+0000', tz='UTC'), latitude=39.90614, longitude=-105.88261, utm_epsg='26913', campaign_name='Fraser Experimental Forest', flags=None, comments=None, observers=None)\n",
+      "ProfileMetaData(site_name='COFEJ2_20191216_1232', date_time=Timestamp('2019-12-16 19:32:00+0000', tz='UTC'), latitude=39.90614, longitude=-105.88261, utm_epsg='26913', campaign_name='Fraser Experimental Forest', flags=None, comments=None, observers=None)\n"
+     ]
+    }
+   ],
+   "source": [
+    "data = download_csv(\"https://n5eil01u.ecs.nsidc.org/DP6/SNOWEX/SNEX20_TS_SP.002/2019.12.16/SNEX20_TS_SP_20191216_1232_COFEJ2_data_density_v02.csv\")\n",
+    "profileData = parse_csv_data(\"data/downloaded_file.csv\")\n",
+    "for index, profile in enumerate(profileData.profiles):\n",
+    "    profile.df.to_csv(\"data/observations{}.csv\".format(index), index=False)\n",
+    "    print(profile.metadata)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "6ccf69f5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Could not find mapping for pit_comments\n",
+      "Could not find mapping for parameter_codes\n"
+     ]
+    }
+   ],
+   "source": [
+    "d = parse_csv_data(\"data/downloaded_file.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "99c7147d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>depth</th>\n",
+       "      <th>bottom_depth</th>\n",
+       "      <th>density</th>\n",
+       "      <th>datetime</th>\n",
+       "      <th>geometry</th>\n",
+       "      <th>layer_thickness</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>97.0</td>\n",
+       "      <td>87.0</td>\n",
+       "      <td>164.0</td>\n",
+       "      <td>2020-02-01 19:20:00+00:00</td>\n",
+       "      <td>POINT (-106.9785 38.92667)</td>\n",
+       "      <td>10.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>87.0</td>\n",
+       "      <td>77.0</td>\n",
+       "      <td>242.0</td>\n",
+       "      <td>2020-02-01 19:20:00+00:00</td>\n",
+       "      <td>POINT (-106.9785 38.92667)</td>\n",
+       "      <td>10.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>77.0</td>\n",
+       "      <td>67.0</td>\n",
+       "      <td>246.0</td>\n",
+       "      <td>2020-02-01 19:20:00+00:00</td>\n",
+       "      <td>POINT (-106.9785 38.92667)</td>\n",
+       "      <td>10.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>67.0</td>\n",
+       "      <td>57.0</td>\n",
+       "      <td>261.0</td>\n",
+       "      <td>2020-02-01 19:20:00+00:00</td>\n",
+       "      <td>POINT (-106.9785 38.92667)</td>\n",
+       "      <td>10.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>57.0</td>\n",
+       "      <td>47.0</td>\n",
+       "      <td>284.0</td>\n",
+       "      <td>2020-02-01 19:20:00+00:00</td>\n",
+       "      <td>POINT (-106.9785 38.92667)</td>\n",
+       "      <td>10.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>47.0</td>\n",
+       "      <td>37.0</td>\n",
+       "      <td>280.0</td>\n",
+       "      <td>2020-02-01 19:20:00+00:00</td>\n",
+       "      <td>POINT (-106.9785 38.92667)</td>\n",
+       "      <td>10.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>37.0</td>\n",
+       "      <td>27.0</td>\n",
+       "      <td>302.0</td>\n",
+       "      <td>2020-02-01 19:20:00+00:00</td>\n",
+       "      <td>POINT (-106.9785 38.92667)</td>\n",
+       "      <td>10.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   depth  bottom_depth  density                  datetime  \\\n",
+       "0   97.0          87.0    164.0 2020-02-01 19:20:00+00:00   \n",
+       "1   87.0          77.0    242.0 2020-02-01 19:20:00+00:00   \n",
+       "2   77.0          67.0    246.0 2020-02-01 19:20:00+00:00   \n",
+       "3   67.0          57.0    261.0 2020-02-01 19:20:00+00:00   \n",
+       "4   57.0          47.0    284.0 2020-02-01 19:20:00+00:00   \n",
+       "5   47.0          37.0    280.0 2020-02-01 19:20:00+00:00   \n",
+       "6   37.0          27.0    302.0 2020-02-01 19:20:00+00:00   \n",
+       "\n",
+       "                     geometry  layer_thickness  \n",
+       "0  POINT (-106.9785 38.92667)             10.0  \n",
+       "1  POINT (-106.9785 38.92667)             10.0  \n",
+       "2  POINT (-106.9785 38.92667)             10.0  \n",
+       "3  POINT (-106.9785 38.92667)             10.0  \n",
+       "4  POINT (-106.9785 38.92667)             10.0  \n",
+       "5  POINT (-106.9785 38.92667)             10.0  \n",
+       "6  POINT (-106.9785 38.92667)             10.0  "
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "profileData.profiles[0].df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "id": "e0f65933",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Could not find mapping for pit_comments\n",
+      "Could not find mapping for parameter_codes\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CSV file downloaded successfully as 'downloaded_file.csv'\n",
+      "   depth  bottom_depth  density                  datetime  \\\n",
+      "0   48.0          38.0    144.0 2019-12-16 19:32:00+00:00   \n",
+      "1   38.0          28.0    213.0 2019-12-16 19:32:00+00:00   \n",
+      "2   28.0          18.0    264.0 2019-12-16 19:32:00+00:00   \n",
+      "3   18.0           8.0    292.0 2019-12-16 19:32:00+00:00   \n",
+      "\n",
+      "                      geometry  layer_thickness  \n",
+      "0  POINT (-105.88261 39.90614)             10.0  \n",
+      "1  POINT (-105.88261 39.90614)             10.0  \n",
+      "2  POINT (-105.88261 39.90614)             10.0  \n",
+      "3  POINT (-105.88261 39.90614)             10.0  \n"
+     ]
+    }
+   ],
+   "source": [
+    "files = [\"https://n5eil01u.ecs.nsidc.org/DP6/SNOWEX/SNEX20_TS_SP.002/2019.12.16/SNEX20_TS_SP_20191216_1232_COFEJ2_data_density_v02.csv\"]\n",
+    "for file in files:\n",
+    "    if \"density\" in file:\n",
+    "        download_csv(file)\n",
+    "        profileData = parse_csv_data(\"data/downloaded_file.csv\")\n",
+    "        print(profileData.profiles[0].df)\n",
+    "        #add_layer_data(profileData.profiles[0].df, profileData.metadata)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "382e1006",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/arendta/git/aaarendt/snowexdb/src/snowexdb\n",
+      "CSV file downloaded successfully as 'downloaded_file.csv'\n"
+     ]
+    }
+   ],
+   "source": [
+    "from snowexdb.utils.data_parser import download_csv\n",
+    "file = \"https://n5eil01u.ecs.nsidc.org/DP6/SNOWEX/SNEX20_TS_SP.002/2019.12.16/SNEX20_TS_SP_20191216_1232_COFEJ2_data_density_v02.csv\"\n",
+    "\n",
+    "download_csv(file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "97bc0270",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import csv\n",
+    "from io import StringIO\n",
+    "\n",
+    "def read_csv_from_url(url):\n",
+    "    \"\"\"\n",
+    "    Reads CSV data from a URL and returns it as a list of dictionaries.\n",
+    "\n",
+    "    Args:\n",
+    "        url (str): The URL of the CSV file.\n",
+    "\n",
+    "    Returns:\n",
+    "        list: A list of dictionaries, where each dictionary represents a row in the CSV file. \n",
+    "              Returns an empty list if there's an error.\n",
+    "    \"\"\"\n",
+    "    try:\n",
+    "        response = requests.get(url)\n",
+    "        response.raise_for_status()  # Raise HTTPError for bad responses (4xx or 5xx)\n",
+    "\n",
+    "        csv_text = StringIO(response.text)\n",
+    "        csv_reader = csv.DictReader(csv_text)\n",
+    "        data = list(csv_reader)\n",
+    "        return data\n",
+    "    except requests.exceptions.RequestException as e:\n",
+    "         print(f\"Request error: {e}\")\n",
+    "         return []\n",
+    "    except csv.Error as e:\n",
+    "        print(f\"CSV parsing error: {e}\")\n",
+    "        return []\n",
+    "\n",
+    "# # Example Usage\n",
+    "# csv_url = collections[0].data_links(\"Data\")[0]  # Replace with the actual URL of your CSV file\n",
+    "# csv_data = read_csv_from_url(csv_url)\n",
+    "\n",
+    "# if csv_data:\n",
+    "#     for row in csv_data:\n",
+    "#         print(row) # Process each row of the CSV data\n",
+    "# else:\n",
+    "#     print(\"Failed to read CSV data.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "7ab37936",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<insitupy.campaigns.snowex.snowex_profile_data_collection.SnowExProfileDataCollection object at 0x7f0ca6f2b7a0>\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "fname = \"data/fake_data.csv\"\n",
+    "file_list = SnowExProfileData.DEFAULT_PRIMARY_VARIABLE_FILES + [\"./overrides.yaml\"]\n",
+    "my_vars = ExtendableVariables(file_list)\n",
+    "my_data = SnowExProfileDataCollection.from_csv(\n",
+    "    fname, allow_map_failure=True,\n",
+    "    # primary_variable_files=file_list,\n",
+    ")\n",
+    "print(my_data)\n"
+   ]
   }
  ],
  "metadata": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "SQLAlchemy >= 2.0.0",
     "sqlmodel",
     "typer",
+    "earthaccess",
 ]
 
 [project.optional-dependencies]

--- a/src/snowexdb/repositories/__init__.py
+++ b/src/snowexdb/repositories/__init__.py
@@ -14,6 +14,13 @@ engine = create_engine(postgresql_url, echo=False)
 
 SQLModel.metadata.create_all(engine)
 
+import earthaccess
+
+auth = earthaccess.login() # credentialing according to earthaccess website
+# https://earthaccess.readthedocs.io/en/latest/howto/authenticate/
+
+if not auth.authenticated:
+    auth.login(strategy="interactive", persist = True)
 
 # import os
 # import logging

--- a/src/snowexdb/scripts/populate_database.py
+++ b/src/snowexdb/scripts/populate_database.py
@@ -6,11 +6,12 @@ from snowexdb.models.instrument import Instrument
 from snowexdb.models.layer import Layer
 from snowexdb.models.site import Site
 from snowexdb.utils.projection import create_geom
-from datetime import datetime
 from pathlib import Path
 
 import logging
 
+from snowexdb.utils.data_parser import download_csv, parse_csv_data
+from snowexdb.utils.access_data import NSIDC_access
 
 INPUT_DIRECTORY = Path(__file__).parent / 'resources/data'
 
@@ -18,27 +19,30 @@ logger = logging.getLogger(__name__)
 
 db_populate_app = typer.Typer()
 
-
-def add_layer_data():
+def add_layer_data(profile_df, metadata):
     """
     Adds snow layer profile data to the database
+
+    Args:
+        profile_df (dataframe): the dataframe of observations
+        metadata (object): the metadata associated with the profile data
+    
     """
     instrument = add_instrument_data()
-    site = add_site_data()
+    site = add_site_data(site_metadata={"latitude": metadata.latitude,
+                                        "longitude": metadata.longitude,
+                                        "elevation": 400, # temporary
+                                        "name":metadata.site_name,
+                                        "date":metadata.date_time})
 
-    sample_layers = INPUT_DIRECTORY / 'layers.csv'
-    
-    with sample_layers.open(mode='r', newline='') as file:
-        csv_reader = csv.DictReader(file)
-
-        for row in csv_reader:
-            csv_data = Layer(depth = row["depth"],
-                              bottom_depth = row["bottom_depth"],
-                              value = row["value"],
-                              comments = row["comments"], 
-                              instrument_id = instrument.id,
-                              site_id = site.id)
-            BaseRepository.add(csv_data)
+    for index, row in profile_df.iterrows():
+        data = Layer(depth=row["depth"],
+                          bottom_depth=row["bottom_depth"],
+                          value=str(row["density"]), #temporary
+                          comments=metadata.comments, 
+                          instrument_id=instrument.id,
+                          site_id=site.id)
+        BaseRepository.add(data)
     logger.info("Layer Added Successfully")
 
 def add_instrument_data():
@@ -57,30 +61,41 @@ def add_instrument_data():
     logger.info("Instrument Added Successfully")
     return instrument
 
-def add_site_data():
+def add_site_data(site_metadata):
     """
     Adds site data to the database
-    """
-    metadata_file = INPUT_DIRECTORY / 'metadata.csv'
 
-    with metadata_file.open(mode='r', newline='') as file:
-        csv_reader = csv.DictReader(file)
-        for row in csv_reader:
-            coordinates = create_geom({"epsg":4326,
-                                      "longitude":row['longitude'],
-                                      "latitude":row['latitude']})
-            site = Site(name=row['site_name'], 
-                        elevation=400,
-                        date = datetime.strptime(row['date'], '%m-%d-%Y'),
-                        geom=coordinates['geom'])
-        BaseRepository.add(site)    
+    Args:
+        site_metadata (dict): dictionary of site metadata elements
+    """
+
+    coordinates = create_geom({"epsg":4326,
+                                "longitude":site_metadata['longitude'],
+                                "latitude":site_metadata['latitude']})
+    site = Site(name=site_metadata['name'], 
+                elevation=site_metadata['elevation'],
+                date=site_metadata['date'],
+                geom=coordinates['geom'])
+    BaseRepository.add(site)    
     logger.info("Site Added Successfully")
     return site
 
-@db_populate_app.command(help="Command to add layer data to the database")
-def add_layer():
-    add_layer_data()
+@db_populate_app.command(help="Add density data to the database")
+def add_density():
+    collections = NSIDC_access("10.5067/KZ43HVLZV6G4")
+    for collection in collections:
+        files = collection.data_links("Data")
+        for file in files:
+            if "density" in file:
+                download_csv(file)
+                profileData = parse_csv_data(INPUT_DIRECTORY / 
+                                             "downloaded_file.csv")
+                for profile in profileData.profiles:
+                    add_layer_data(profile.df, profile.metadata)
+                print("{} file imported!".format(file))
 
-@db_populate_app.command(help="Add site data to the database")
-def add_site():
-    add_site_data()
+# TODO: determine right level of loops to add the site and instrument data, 
+# not for each profile object as being done now
+
+# for temporarily testing with a single file
+        #files = ["https://n5eil01u.ecs.nsidc.org/DP6/SNOWEX/SNEX20_TS_SP.002/2019.12.16/SNEX20_TS_SP_20191216_1232_COFEJ2_data_density_v02.csv"]

--- a/src/snowexdb/utils/access_data.py
+++ b/src/snowexdb/utils/access_data.py
@@ -1,0 +1,16 @@
+import earthaccess
+
+def NSIDC_access(doi):
+    """
+    Accesses data from NSIDC using the earthaccess library
+
+    Args:
+        doi (str): The DOI of the dataset to access.
+        
+    Returns:
+        collections: a collections data layer
+    """
+    collections = earthaccess.search_data(
+        doi = doi,
+    )
+    return collections

--- a/src/snowexdb/utils/data_parser.py
+++ b/src/snowexdb/utils/data_parser.py
@@ -1,0 +1,55 @@
+from insitupy.campaigns.snowex import SnowExProfileData
+from insitupy.variables import ExtendableVariables
+
+from insitupy.campaigns.snowex.snowex_profile_data_collection \
+     import SnowExProfileDataCollection
+
+import requests
+import os
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+def download_csv(csv_url):
+    """
+    Download CSV file from the given URL
+
+    Args:
+        csv_url (str): the URL of the CSV file to download
+    
+    Output:
+        downloaded_file.csv: a temporary local file that gets consistently
+        overwritten after it is uploaded to the database    
+    """
+    response = requests.get(csv_url)
+    if response.status_code == 200:
+        with open(ROOT_DIR + 
+                  "/scripts/resources/data/downloaded_file.csv", "wb") as f:
+            f.write(response.content)
+    else:
+        print(f"Failed to download the file. Status code: \
+              {response.status_code}")
+
+
+def parse_csv_data(fname):
+    """
+    Parse the CSV data from the given file name, using insitupy library.
+    
+    Args:
+        fname (str): the name of the CSV file to parse.
+    
+    Returns:
+        profile_data (obj): profile data object containing the observations
+        and the metadata. 
+    
+    Unclear why primary_variable_files not working - check latest insitupy
+    updates?
+    """
+
+    file_list = SnowExProfileData.DEFAULT_PRIMARY_VARIABLE_FILES + \
+    ["./overrides.yaml"]
+    my_vars = ExtendableVariables(file_list)
+    profile_data = SnowExProfileDataCollection.from_csv(
+        fname, allow_map_failure=True,
+        # primary_variable_files=file_list, 
+    )
+    return profile_data

--- a/src/snowexdb/utils/overrides.yaml
+++ b/src/snowexdb/utils/overrides.yaml
@@ -1,0 +1,6 @@
+DENSITY:
+  code: rho
+  map_from:
+  - density
+  - density_mean
+  - and_map_from_this


### PR DESCRIPTION
This PR integrates two main changes:
* creates the scaffolding for direct script-level access for import of NSIDC files using the [NASA earthaccess](https://earthaccess.readthedocs.io/) library
* uses [insitypy](https://github.com/M3Works/insitupy/) to parse the observations and metadata

The database ingest scripts now read real data for the first time and have been changed to work with the native data types returned from `insitupy`, i.e. dataframes for the observations and a metadata object for each metadata element.  